### PR TITLE
Style/mobile first

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,30 +4,97 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Berlin Transportation</title>
+
+  <!-- Tus estilos -->
   <link rel="stylesheet" href="styles.css" />
+
+  <!-- Leaflet CSS -->
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+    crossorigin=""
+  />
 </head>
 <body>
   <header>
     <h1>Berlin Transportation</h1>
     <div class="actions">
-      <input id="search" placeholder="Buscar estación..." />
-      <button id="btnSearch">Buscar</button>
+      <input id="search" placeholder="Ej: Alexanderplatz" />
+      <button id="btnSearch">Ir</button>
     </div>
   </header>
 
   <main>
     <aside id="panel">
-      <div id="status">Listo · CSS cargado ✅</div>
+      <div id="status">Mapa listo ✅</div>
       <ul id="results">
-        <li>Ejemplo de estación</li>
-        <li>Otra estación</li>
+        <li data-lat="52.5219" data-lng="13.4132">Alexanderplatz</li>
+        <li data-lat="52.5251" data-lng="13.3694">Hauptbahnhof</li>
       </ul>
     </aside>
+
+    <!-- Contenedor del mapa -->
     <section id="map"></section>
   </main>
 
   <footer>
-    <small>Demo educativa</small>
+    <small>Demo local con Leaflet</small>
   </footer>
+
+  <!-- Leaflet JS -->
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+    crossorigin=""
+  ></script>
+
+  <!-- Script mínimo para iniciar el mapa -->
+  <script>
+    // Crear el mapa centrado en Berlín
+    const map = L.map('map', { zoomControl: true })
+      .setView([52.520008, 13.404954], 12); // Berlín
+
+    // Capa base OSM
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    // Marcador de ejemplo
+    let marker = L.marker([52.520008, 13.404954]).addTo(map);
+    marker.bindPopup('<b>Berlín</b><br/>Mapa funcionando.').openPopup();
+
+    // Click en resultados del panel para mover el mapa
+    document.getElementById('results').addEventListener('click', (e) => {
+      const li = e.target.closest('li');
+      if (!li) return;
+      const lat = parseFloat(li.dataset.lat);
+      const lng = parseFloat(li.dataset.lng);
+      map.setView([lat, lng], 15);
+      if (marker) marker.remove();
+      marker = L.marker([lat, lng]).addTo(map).bindPopup(li.textContent).openPopup();
+    });
+
+    // Búsqueda simple (mock): Alexanderplatz / Hauptbahnhof
+    document.getElementById('btnSearch').addEventListener('click', () => {
+      const q = document.getElementById('search').value.trim().toLowerCase();
+      const options = {
+        'alexanderplatz': [52.5219, 13.4132],
+        'hauptbahnhof': [52.5251, 13.3694],
+      };
+      if (options[q]) {
+        const [lat, lng] = options[q];
+        map.setView([lat, lng], 15);
+        if (marker) marker.remove();
+        marker = L.marker([lat, lng]).addTo(map).bindPopup(q).openPopup();
+      } else {
+        alert('Prueba "Alexanderplatz" o "Hauptbahnhof" (mock).');
+      }
+    });
+
+    // Arreglo típico: asegurar que el mapa calcule bien el tamaño al cargar
+    setTimeout(() => map.invalidateSize(), 0);
+  </script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Berlin Transportation</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Berlin Transportation</h1>
+    <div class="actions">
+      <input id="search" placeholder="Buscar estación..." />
+      <button id="btnSearch">Buscar</button>
+    </div>
+  </header>
+
+  <main>
+    <aside id="panel">
+      <div id="status">Listo · CSS cargado ✅</div>
+      <ul id="results">
+        <li>Ejemplo de estación</li>
+        <li>Otra estación</li>
+      </ul>
+    </aside>
+    <section id="map"></section>
+  </main>
+
+  <footer>
+    <small>Demo educativa</small>
+  </footer>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,27 @@
+/* Reset y tokens */
+*{box-sizing:border-box} :root{--bg:#f8fafc;--fg:#0f172a;--muted:#64748b;--b:#e2e8f0;--accent:#0ea5e9}
+html,body{height:100%}
+body{margin:0;font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;color:var(--fg);background:#fff}
+
+/* Layout móvil primero */
+header,footer{padding:12px 16px;background:var(--bg);border-bottom:1px solid var(--b)}
+header h1{margin:0;font-size:18px}
+main{display:flex;flex-direction:column;gap:12px;padding:12px}
+#panel{order:1;border:1px solid var(--b);border-radius:12px;padding:12px}
+#status{font-size:12px;color:var(--muted);margin-bottom:8px}
+#results{list-style:none;margin:0;padding:0;display:grid;gap:8px}
+#results li{padding:10px;border:1px solid var(--b);border-radius:10px;cursor:pointer}
+#results li:hover{background:var(--bg)}
+#map{height:60vh;border:1px solid var(--b);border-radius:12px}
+
+/* Controles */
+.actions{display:flex;gap:8px;margin-top:8px}
+.actions input{flex:1;min-width:0;padding:10px;border:1px solid var(--b);border-radius:10px}
+.actions button{padding:10px 14px;border:1px solid var(--accent);background:var(--accent);color:#fff;border-radius:10px;cursor:pointer}
+
+/* Tablet/desktop */
+@media (min-width: 980px){
+  main{flex-direction:row;height:calc(100vh - 96px);padding:16px}
+  #panel{width:360px;height:100%;overflow:auto}
+  #map{flex:1;height:100%}
+}


### PR DESCRIPTION
### Descripción
Se implementó la estructura y estilos iniciales del frontend para la aplicación **Berlin Transportation App**.

### Cambios realizados
- Se creó el archivo `frontend/styles.css` con diseño mobile-first.
  - Hoja de estilos propia.
  - Integración de **Leaflet.js** para mostrar el mapa de Berlín.
  - Panel lateral con estaciones de ejemplo y campo de búsqueda mock.
- Se probó localmente la carga del mapa con OpenStreetMap (sin backend aún).

### Cómo probarlo localmente
1. Clonar la rama:
   ```bash
   git checkout style/mobile-first

2. Abrir en navegador:
frontend/index.html

3. Verificar que:
El mapa carga correctamente.
Se puede hacer clic en “Alexanderplatz” o “Hauptbahnhof”.
El diseño se adapta en móvil (layout vertical).
Closes #12
